### PR TITLE
support hour minute seconds miliseconds formatting from nepalidates format method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ const d6 = new NepaliDate(2075, 13, 1) // '2076/2/1'
 const d7 = new NepaliDate(2075, -1, 1) // '2074/12/1'
 
 // Format date in nepali
-d6.format("yyyy-mm-dd") // २०७५-०२-०१
-d6.format("YYY-MM-DD") // 075-02-01
-d6.format("mmmm d, yyyy ddd") // जेष्ठ १, २०७५ मंगल
+d6.format("YY-MM-DD") // 75-02-01
+d6.formatNepali("YYYY-MM-DD") // २०७५-०२-०१
 d6.format("MMM D, YYYY DDD") // Jes 1, 2075 Tue
+d6.formatNepali("MMMM D, YYYY ddd") // जेष्ठ १, २०७५ मंगल
 
 // Retrieve english date from NepaliDate
 d1.getEnglishDate() // Return Date object
@@ -171,9 +171,9 @@ Hours, minutes, seconds and milliseconds similar to javascript `Date`.
 
 Retrieve Date object corresponding to the Nepali date
 
-## set(year, month, date)
+## set(year, month, date, hour=0, minute=0, second=0, ms=0)
 
-Change date to given year, month and day of month
+Change date to given year, month, day of month, hour, minute, second, and ms
 
 ## setYear(year)
 
@@ -197,34 +197,36 @@ the date to the last date of previous month, setting date to 35 will
 change the date to some day in the next month (3, 4, 5, depending on
 how many days are there in the month)
 
-## format(formatStr)
+## format
 
 Format the date to provide various output based on format string
 
-<pre>
-YYYY - 4 digit of year (2075)
-yyyy - 4 digit of year in nepali unicode (२०७५)
-YYY  - 3 digit of year (075)
-yyy  - 3 digit of year (०७५)
-YY   - 2 digit of year
-yy   - 2 digit of year in nepali unicode (७५)
-M    - month number (1 - 12)
-m    - month number (१ - १२) in nepali unicode
-MM   - month number with 0 padding (01 - 12)
-mm   - month number in nepali unicode with 0 padding - (०१-१२)
-MMM  - short month name (Bai, Jes, Asa, Shr, etc.)
-mmm  - short month name in nepali unicde (ब‍ै, जे, अ, श्रा, etc)
-MMMM - full month name (Baisakh, Jestha, Asar, ...)
-mmmm - full month name nepali (बैसाख, जेष्ठ, ...)
-D    - Day of Month (1, 2, ... 31, 32)
-d    - Day of Month in Nepali unicode (१, २, ३ ... ३१, ३२)
-DD   - Day of Month with zero padding (01, 02, ...)
-dd   - Day of Month with zero padding in Nepali unicode (०१, ०२, ...)
-DDD  - Day of Week short form (Sun, Mon, Tue, ...)
-ddd  - Day of week in short form nepali (आइत, सोम, ...)
-DDDD - Day of week full form (Sunday, Monday, Tuesday, ...)
-dddd - Day of week full form nepali (आइतबार, सोमबार, ...)
-</pre>
+```js
+const myNepaliDate = NepaliDate()
+myNepaliDate.format("YYYY-MM-DD HH:mm:ss")
+```
+
+| Format Token | Description                      | Example             |
+|--------------|----------------------------------|---------------------|
+| YYYY         | 4-digit year                     | 2023                |
+| YY           | 2-digit year                     | 23                  |
+| MMMM         | Full month name                  | January             |
+| MMM          | Abbreviated month name           | Jan                 |
+| MM           | 2-digit month                    | 01-12               |
+| DD           | 2-digit day of the month         | 01-31               |
+| dddd         | Full day of the week             | Monday              |
+| ddd          | Abbreviated day of the week      | Mon                 |
+| HH           | 2-digit hour (24-hour format)    | 00-23               |
+| hh           | 2-digit hour (12-hour format)    | 01-12               |
+| mm           | 2-digit minutes                  | 00-59               |
+| ss           | 2-digit seconds                  | 00-59               |
+| SSS          | 3-digit milliseconds             | 000-999             |
+| A            | Uppercase AM/PM                  | AM or PM            |
+| a            | Lowercase am/pm                  | am or pm            |
 
 Any other character is printed as is. If you need to print the
 special characters (YMDymd), enclose them within quotes.
+
+## formatNepali
+
+`formatNepali` is similar to the `format` method. It returns the representation of the NepaliDate object in the specified format in the Nepali.

--- a/__tests__/NepaliDate.spec.ts
+++ b/__tests__/NepaliDate.spec.ts
@@ -26,11 +26,11 @@ describe("NepaliDate", () => {
 
     it("checks format", () => {
         const n = new NepaliDate("2038-07-15")
-        // expect(n.format("yyyy/mm/dd")).toBe("२०३८/०७/१५")
-        // expect(n.format("yy-m-d")).toBe("३८-७-१५")
+        expect(n.formatNepali("YYYY/MM/DD")).toBe("२०३८/०७/१५")
+        expect(n.formatNepali("YY-M-D")).toBe("३८-७-१५")
         expect(n.format("YYYY-MM-DD")).toBe("2038-07-15")
         expect(n.format("YY-M-D")).toBe("38-7-15")
-        // expect(n.format("Y-MMMM-ddd")).toBe("38-Kartik-शनि")
+        expect(n.formatNepali("Y-MMMM-ddd")).toBe("२०३८-कार्तिक-शनि")
         expect(n.format('"YYY" YYYY')).toBe("YYY 2038")
     })
 

--- a/__tests__/NepaliDate.spec.ts
+++ b/__tests__/NepaliDate.spec.ts
@@ -29,7 +29,7 @@ describe("NepaliDate", () => {
         // expect(n.format("yyyy/mm/dd")).toBe("२०३८/०७/१५")
         // expect(n.format("yy-m-d")).toBe("३८-७-१५")
         expect(n.format("YYYY-MM-DD")).toBe("2038-07-15")
-        expect(n.format("Y-M-D")).toBe("38-7-15")
+        expect(n.format("YY-M-D")).toBe("38-7-15")
         // expect(n.format("Y-MMMM-ddd")).toBe("38-Kartik-शनि")
         expect(n.format('"YYY" YYYY')).toBe("YYY 2038")
     })

--- a/__tests__/NepaliDate.spec.ts
+++ b/__tests__/NepaliDate.spec.ts
@@ -26,11 +26,11 @@ describe("NepaliDate", () => {
 
     it("checks format", () => {
         const n = new NepaliDate("2038-07-15")
-        expect(n.format("yyyy/mm/dd")).toBe("२०३८/०७/१५")
-        expect(n.format("yy-m-d")).toBe("३८-७-१५")
+        // expect(n.format("yyyy/mm/dd")).toBe("२०३८/०७/१५")
+        // expect(n.format("yy-m-d")).toBe("३८-७-१५")
         expect(n.format("YYYY-MM-DD")).toBe("2038-07-15")
         expect(n.format("Y-M-D")).toBe("38-7-15")
-        expect(n.format("Y-MMMM-ddd")).toBe("38-Kartik-शनि")
+        // expect(n.format("Y-MMMM-ddd")).toBe("38-Kartik-शनि")
         expect(n.format('"YYY" YYYY')).toBe("YYY 2038")
     })
 

--- a/__tests__/format.spec.ts
+++ b/__tests__/format.spec.ts
@@ -6,7 +6,7 @@ describe('format', () => {
     const nepaliDate2 = new NepaliDate(2080, 1, 8, 7, 55)
     const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40)
 
-    it('should format the NepaliDate for the provided format string', () => {
+    it('should format NepaliDate for the provided format string', () => {
         const formatStr = 'YYYY-MM-DD'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('2080-02-32')
@@ -36,49 +36,99 @@ describe('format', () => {
     //     expect(formattedDate).toEqual('2080-02-32 07:40')
     //   })
 
-    it('should format the NepaliDate with the non leading zeros format', () => {
+    it('should format NepaliDate with the non leading zeros format', () => {
         const formatStr = 'YYYY-M-D'
         const formattedDate = format(nepaliDate2, formatStr)
         expect(formattedDate).toEqual('2080-2-8')
     })
 
-    it('should format the NepaliDate for 2 digit year format', () => {
+    it('should not format NepaliDate for invalid format size', () => {
+        const formatStr = 'YYYYY-MMMMM-DDD ddddd' // invalid format
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('YYYYY-MMMMM-DDD ddddd')
+    })
+
+    /* individual format tests (positive cases) */
+
+    it('should format NepaliDate for YYYY: 4 digit year', () => {
+        const formatStr = 'YYYY'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080')
+    })
+
+    it('should format NepaliDate for Y: 4 digit year', () => {
+        const formatStr = 'Y'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080')
+    })
+
+    it('should format NepaliDate for YYYY: 4 digit year', () => {
+        const formatStr = 'YYYY'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080')
+    })
+
+    it('should format NepaliDate for YY: 2 digit year', () => {
         const formatStr = 'YY'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('80')
     })
 
-    it('should format the NepaliDate for full month name', () => {
+    it('should format NepaliDate for MMMM: full month name', () => {
         const formatStr = 'MMMM'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('Jestha')
     })
 
-    it('should format the NepaliDate for month abbr name', () => {
+    it('should format NepaliDate for MMM: month abbr name', () => {
         const formatStr = 'MMM'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('Jes')
     })
-    
-    it('should format the NepaliDate for week day name', () => {
+
+    it('should format NepaliDate for MM: month', () => {
+        const formatStr = 'MM'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('02')
+    })
+
+    it('should format NepaliDate for M: month with non leading zero', () => {
+        const formatStr = 'M'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2')
+    })
+
+    it('should format NepaliDate for DD: day', () => {
+        const formatStr = 'DD'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('32')
+    })
+
+    it('should format NepaliDate for D: day', () => {
+        const formatStr = 'D'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('32')
+    })
+
+    it('should format NepaliDate for dddd: week day name', () => {
         const formatStr = 'dddd'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('Thursday')
     })
 
-    it('should format the NepaliDate for week day abbr name', () => {
+    it('should format NepaliDate for ddd: week day abbr name', () => {
         const formatStr = 'ddd'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('Thu')
     })
 
-    it('should format the NepaliDate for week day abbr name 2', () => {
+    it('should format NepaliDate for dd: week day abbr name', () => {
         const formatStr = 'dd'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('Thu')
     })
 
-    it('should format the NepaliDate for week day number', () => {
+    it('should format NepaliDate for d: week day number', () => {
         const formatStr = 'd'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('4')

--- a/__tests__/format.spec.ts
+++ b/__tests__/format.spec.ts
@@ -3,8 +3,8 @@ import NepaliDate from '../src/NepaliDate'
 
 describe('format', () => {
     const nepaliDate1 = new NepaliDate(2080, 1, 32, 7, 40)
-    const nepaliDate2 = new NepaliDate(2080, 1, 8, 7, 55)
-    const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40)
+    const nepaliDate2 = new NepaliDate(2080, 1, 8, 20, 55, 32)
+    const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40, 413)
 
     it('should format NepaliDate for the provided format string', () => {
         const formatStr = 'YYYY-MM-DD'
@@ -18,23 +18,17 @@ describe('format', () => {
         expect(formattedDate).toEqual('2080 2080')
     })
 
-    //   it('should handle a format string with multiple formats', () => {
-    //     const formatStr = 'YYYY-MM-DD HH:mm'
-    //     const formattedDate = format(nepaliDate1, formatStr)
-    //     expect(formattedDate).toEqual('2080-02-32 07:40')
-    //   })
+    it('should handle a format string with multiple formats', () => {
+        const formatStr = 'YYYY-MM-DD HH:mm'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080-02-32 07:40')
+    })
 
-    //   it('should handle a format string with unknown tokens', () => {
-    //     const formatStr = 'YYYY-QQ-DD HH:mm:ss'
-    //     const formattedDate = format(nepaliDate1, formatStr)
-    //     expect(formattedDate).toEqual('2080-QQ-32 07:40:00')
-    //   })
-
-    //   it('should handle a format string with escaped characters', () => {
-    //     const formatStr = 'YYYY-MM-DD \\HH:mm'
-    //     const formattedDate = format(nepaliDate1, formatStr)
-    //     expect(formattedDate).toEqual('2080-02-32 07:40')
-    //   })
+    it('should handle a format string with unknown formats', () => {
+        const formatStr = 'YYYY-QQ-DD HH:mm:ss'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080-QQ-32 07:40:00')
+    })
 
     it('should format NepaliDate with the non leading zeros format', () => {
         const formatStr = 'YYYY-M-D'
@@ -133,13 +127,109 @@ describe('format', () => {
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('4')
     })
+
+    it('should format NepaliDate for HH: 24-hour', () => {
+        const formatStr = 'HH'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('07')
+    })
+
+    it('should format NepaliDate for H:  24-hour', () => {
+        const formatStr = 'H'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('16')
+    })
+
+    it('should format NepaliDate for hh: 12-hour', () => {
+        const formatStr = 'hh'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('07')
+    })
+
+    it('should format NepaliDate for h: 12-hour', () => {
+        const formatStr = 'h'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('4')
+    })
+
+    it('should format NepaliDate for mm: minute', () => {
+        const formatStr = 'mm'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('09')
+    })
+
+    it('should format NepaliDate for m: minute', () => {
+        const formatStr = 'm'
+        const formattedDate = format(nepaliDate2, formatStr)
+        expect(formattedDate).toEqual('55')
+    })
+
+    it('should format NepaliDate for ss: second', () => {
+        const formatStr = 'ss'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('00')
+    })
+
+    it('should format NepaliDate for s: second', () => {
+        const formatStr = 's'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('40')
+    })
+
+    it('should format NepaliDate for S: millisecond', () => {
+        const formatStr = 'S'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('4')
+    })
+
+    it('should format NepaliDate for SS: millisecond', () => {
+        const formatStr = 'SS'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('41')
+    })
+
+    it('should format NepaliDate for SSS: millisecond', () => {
+        const formatStr = 'SSS'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('413')
+    })
+
+    it('should format NepaliDate for SSSSSSSSS: millisecond', () => {
+        const formatStr = 'SSSSSSSSS'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('413000000')
+    })
+
+    it('should format NepaliDate (AM) for A: Uppercase AM/PM indicator (e.g., AM, PM)', () => {
+        const formatStr = 'A'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('AM')
+    })
+
+    it('should format NepaliDate (PM) for A: Uppercase AM/PM indicator (e.g., AM, PM)', () => {
+        const formatStr = 'A'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('PM')
+    })
+
+    it('should format NepaliDate (AM) for a: Lowercase AM/PM indicator (e.g., am, pm)', () => {
+        const formatStr = 'a'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('am')
+    })
+
+    it('should format NepaliDate (PM) for a: Lowercase AM/PM indicator (e.g., am, pm)', () => {
+        const formatStr = 'a'
+        const formattedDate = format(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('pm')
+    })
 })
 
 
 describe('formatNepali', () => {
     const nepaliDate1 = new NepaliDate(2080, 1, 32, 7, 40)
-    const nepaliDate2 = new NepaliDate(2080, 1, 8, 7, 55)
-    const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40)
+    const nepaliDate2 = new NepaliDate(2080, 1, 8, 20, 55, 32)
+    const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40, 413)
 
     it('should format NepaliDate for the provided format string', () => {
         const formatStr = 'YYYY-MM-DD'
@@ -153,23 +243,18 @@ describe('formatNepali', () => {
         expect(formattedDate).toEqual('२०८० २०८०')
     })
 
-    //   it('should handle a format string with multiple formats', () => {
-    //     const formatStr = 'YYYY-MM-DD HH:mm'
-    //     const formattedDate = formatNepali(nepaliDate1, formatStr)
-    //     expect(formattedDate).toEqual('2080-02-32 07:40')
-    //   })
+    it('should handle a format string with multiple formats', () => {
+        const formatStr = 'YYYY-MM-DD HH:mm'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८०-०२-३२ ०७:४०')
+    })
 
-    //   it('should handle a format string with unknown tokens', () => {
-    //     const formatStr = 'YYYY-QQ-DD HH:mm:ss'
-    //     const formattedDate = formatNepali(nepaliDate1, formatStr)
-    //     expect(formattedDate).toEqual('2080-QQ-32 07:40:00')
-    //   })
+    it('should handle a format string with unknown formats', () => {
+        const formatStr = 'YYYY-QQ-DD HH:mm:ss'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८०-QQ-३२ ०७:४०:००')
+    })
 
-    //   it('should handle a format string with escaped characters', () => {
-    //     const formatStr = 'YYYY-MM-DD \\HH:mm'
-    //     const formattedDate = formatNepali(nepaliDate1, formatStr)
-    //     expect(formattedDate).toEqual('2080-02-32 07:40')
-    //   })
 
     it('should format NepaliDate with the non leading zeros format', () => {
         const formatStr = 'YYYY-M-D'
@@ -267,5 +352,77 @@ describe('formatNepali', () => {
         const formatStr = 'd'
         const formattedDate = formatNepali(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('४')
+    })
+
+    it('should format NepaliDate for HH: 24-hour', () => {
+        const formatStr = 'HH'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('०७')
+    })
+
+    it('should format NepaliDate for H:  24-hour', () => {
+        const formatStr = 'H'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('१६')
+    })
+
+    it('should format NepaliDate for hh: 12-hour', () => {
+        const formatStr = 'hh'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('०७')
+    })
+
+    it('should format NepaliDate for h: 12-hour', () => {
+        const formatStr = 'h'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('४')
+    })
+
+    it('should format NepaliDate for mm: minute', () => {
+        const formatStr = 'mm'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('०९')
+    })
+
+    it('should format NepaliDate for m: minute', () => {
+        const formatStr = 'm'
+        const formattedDate = formatNepali(nepaliDate2, formatStr)
+        expect(formattedDate).toEqual('५५')
+    })
+
+    it('should format NepaliDate for ss: second', () => {
+        const formatStr = 'ss'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('००')
+    })
+
+    it('should format NepaliDate for s: second', () => {
+        const formatStr = 's'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('४०')
+    })
+
+    it('should format NepaliDate for S: millisecond', () => {
+        const formatStr = 'S'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('४')
+    })
+
+    it('should format NepaliDate for SS: millisecond', () => {
+        const formatStr = 'SS'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('४१')
+    })
+
+    it('should format NepaliDate for SSS: millisecond', () => {
+        const formatStr = 'SSS'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('४१३')
+    })
+
+    it('should format NepaliDate for SSSSSSSSS: millisecond', () => {
+        const formatStr = 'SSSSSSSSS'
+        const formattedDate = formatNepali(nepaliDate3, formatStr)
+        expect(formattedDate).toEqual('४१३००००००')
     })
 })

--- a/__tests__/format.spec.ts
+++ b/__tests__/format.spec.ts
@@ -1,0 +1,86 @@
+import format from '../src/format'
+import NepaliDate from '../src/NepaliDate'
+
+describe('format', () => {
+    const nepaliDate1 = new NepaliDate(2080, 1, 32, 7, 40)
+    const nepaliDate2 = new NepaliDate(2080, 1, 8, 7, 55)
+    const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40)
+
+    it('should format the NepaliDate for the provided format string', () => {
+        const formatStr = 'YYYY-MM-DD'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080-02-32')
+    })
+
+    it('should handle a format string with repeated formats', () => {
+        const formatStr = 'YYYY YYYY'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('2080 2080')
+    })
+
+    //   it('should handle a format string with multiple formats', () => {
+    //     const formatStr = 'YYYY-MM-DD HH:mm'
+    //     const formattedDate = format(nepaliDate1, formatStr)
+    //     expect(formattedDate).toEqual('2080-02-32 07:40')
+    //   })
+
+    //   it('should handle a format string with unknown tokens', () => {
+    //     const formatStr = 'YYYY-QQ-DD HH:mm:ss'
+    //     const formattedDate = format(nepaliDate1, formatStr)
+    //     expect(formattedDate).toEqual('2080-QQ-32 07:40:00')
+    //   })
+
+    //   it('should handle a format string with escaped characters', () => {
+    //     const formatStr = 'YYYY-MM-DD \\HH:mm'
+    //     const formattedDate = format(nepaliDate1, formatStr)
+    //     expect(formattedDate).toEqual('2080-02-32 07:40')
+    //   })
+
+    it('should format the NepaliDate with the non leading zeros format', () => {
+        const formatStr = 'YYYY-M-D'
+        const formattedDate = format(nepaliDate2, formatStr)
+        expect(formattedDate).toEqual('2080-2-8')
+    })
+
+    it('should format the NepaliDate for 2 digit year format', () => {
+        const formatStr = 'YY'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('80')
+    })
+
+    it('should format the NepaliDate for full month name', () => {
+        const formatStr = 'MMMM'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('Jestha')
+    })
+
+    it('should format the NepaliDate for month abbr name', () => {
+        const formatStr = 'MMM'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('Jes')
+    })
+    
+    it('should format the NepaliDate for week day name', () => {
+        const formatStr = 'dddd'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('Thursday')
+    })
+
+    it('should format the NepaliDate for week day abbr name', () => {
+        const formatStr = 'ddd'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('Thu')
+    })
+
+    it('should format the NepaliDate for week day abbr name 2', () => {
+        const formatStr = 'dd'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('Thu')
+    })
+
+    it('should format the NepaliDate for week day number', () => {
+        const formatStr = 'd'
+        const formattedDate = format(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('4')
+    })
+})

--- a/__tests__/format.spec.ts
+++ b/__tests__/format.spec.ts
@@ -1,4 +1,4 @@
-import format from '../src/format'
+import { format, formatNepali } from '../src/format'
 import NepaliDate from '../src/NepaliDate'
 
 describe('format', () => {
@@ -132,5 +132,140 @@ describe('format', () => {
         const formatStr = 'd'
         const formattedDate = format(nepaliDate1, formatStr)
         expect(formattedDate).toEqual('4')
+    })
+})
+
+
+describe('formatNepali', () => {
+    const nepaliDate1 = new NepaliDate(2080, 1, 32, 7, 40)
+    const nepaliDate2 = new NepaliDate(2080, 1, 8, 7, 55)
+    const nepaliDate3 = new NepaliDate(2080, 8, 15, 16, 9, 40)
+
+    it('should format NepaliDate for the provided format string', () => {
+        const formatStr = 'YYYY-MM-DD'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८०-०२-३२')
+    })
+
+    it('should handle a format string with repeated formats', () => {
+        const formatStr = 'YYYY YYYY'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८० २०८०')
+    })
+
+    //   it('should handle a format string with multiple formats', () => {
+    //     const formatStr = 'YYYY-MM-DD HH:mm'
+    //     const formattedDate = formatNepali(nepaliDate1, formatStr)
+    //     expect(formattedDate).toEqual('2080-02-32 07:40')
+    //   })
+
+    //   it('should handle a format string with unknown tokens', () => {
+    //     const formatStr = 'YYYY-QQ-DD HH:mm:ss'
+    //     const formattedDate = formatNepali(nepaliDate1, formatStr)
+    //     expect(formattedDate).toEqual('2080-QQ-32 07:40:00')
+    //   })
+
+    //   it('should handle a format string with escaped characters', () => {
+    //     const formatStr = 'YYYY-MM-DD \\HH:mm'
+    //     const formattedDate = formatNepali(nepaliDate1, formatStr)
+    //     expect(formattedDate).toEqual('2080-02-32 07:40')
+    //   })
+
+    it('should format NepaliDate with the non leading zeros format', () => {
+        const formatStr = 'YYYY-M-D'
+        const formattedDate = formatNepali(nepaliDate2, formatStr)
+        expect(formattedDate).toEqual('२०८०-२-८')
+    })
+
+    it('should not format NepaliDate for invalid format size', () => {
+        const formatStr = 'YYYYY-MMMMM-DDD ddddd' // invalid format
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('YYYYY-MMMMM-DDD ddddd')
+    })
+
+    /* individual format tests (positive cases) */
+
+    it('should format NepaliDate for YYYY: 4 digit year', () => {
+        const formatStr = 'YYYY'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८०')
+    })
+
+    it('should format NepaliDate for Y: 4 digit year', () => {
+        const formatStr = 'Y'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८०')
+    })
+
+    it('should format NepaliDate for YYYY: 4 digit year', () => {
+        const formatStr = 'YYYY'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२०८०')
+    })
+
+    it('should format NepaliDate for YY: 2 digit year', () => {
+        const formatStr = 'YY'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('८०')
+    })
+
+    it('should format NepaliDate for MMMM: full month name', () => {
+        const formatStr = 'MMMM'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('जेठ')
+    })
+
+    it('should format NepaliDate for MMM: month abbr name', () => {
+        const formatStr = 'MMM'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('जे')
+    })
+
+    it('should format NepaliDate for MM: month', () => {
+        const formatStr = 'MM'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('०२')
+    })
+
+    it('should format NepaliDate for M: month with non leading zero', () => {
+        const formatStr = 'M'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('२')
+    })
+
+    it('should format NepaliDate for DD: day', () => {
+        const formatStr = 'DD'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('३२')
+    })
+
+    it('should format NepaliDate for D: day', () => {
+        const formatStr = 'D'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('३२')
+    })
+
+    it('should format NepaliDate for dddd: week day name', () => {
+        const formatStr = 'dddd'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('बिहिबार')
+    })
+
+    it('should format NepaliDate for ddd: week day abbr name', () => {
+        const formatStr = 'ddd'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('बिहि')
+    })
+
+    it('should format NepaliDate for dd: week day abbr name', () => {
+        const formatStr = 'dd'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('बिहि')
+    })
+
+    it('should format NepaliDate for d: week day number', () => {
+        const formatStr = 'd'
+        const formattedDate = formatNepali(nepaliDate1, formatStr)
+        expect(formattedDate).toEqual('४')
     })
 })

--- a/src/NepaliDate.ts
+++ b/src/NepaliDate.ts
@@ -1,5 +1,5 @@
 import dateConverter from "./dateConverter"
-import format from "./format"
+import { format, formatNepali } from "./format"
 import { getDate, getNepalDateAndTime } from "./utils"
 import { validateTime } from "./validators"
 
@@ -294,6 +294,15 @@ class NepaliDate {
 
     format(formatStr: string) {
         return format(this, formatStr)
+    }
+
+    /**
+     * Returns a string representation of the NepaliDate object in the specified format in the Nepali (Devanagari).
+     * @param formatStr The format string for the desired output.
+     * @returns  A string representation of the NepaliDate object in the specified format.
+     */
+    formatNepali(formatStr: string) {
+        return formatNepali(this, formatStr)
     }
 
     toString(): string {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,45 @@
 export const UTC_OFFSET_IN_MS = 20700000 // 5 hours 45 minutes in ms
+
+export const MONTHS_EN = [
+    "Baisakh",
+    "Jestha",
+    "Asar",
+    "Shrawan",
+    "Bhadra",
+    "Aswin",
+    "Kartik",
+    "Mangsir",
+    "Poush",
+    "Magh",
+    "Falgun",
+    "Chaitra",
+]
+
+export const MONTHS_SHORT_EN = ["Bai", "Jes", "Asa", "Shr", "Bhd", "Asw", "Kar", "Man", "Pou", "Mag", "Fal", "Cha"]
+
+export const MONTHS_NP = [
+    "बैशाख",
+    "जेठ",
+    "असार",
+    "श्रावण",
+    "भाद्र",
+    "आश्विन",
+    "कार्तिक",
+    "मंसिर",
+    "पौष",
+    "माघ",
+    "फाल्गुण",
+    "चैत्र",
+]
+
+export const MONTHS_SHORT_NP = ["बै", "जे", "अ", "श्रा", "भा", "आ", "का", "मं", "पौ", "मा", "फा", "चै"]
+
+export const NUM_NP = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"]
+
+export const WEEKDAYS_SHORT_EN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+export const WEEKDAYS_LONG_EN = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+export const WEEKDAYS_SHORT_NP = ["आइत", "सोम", "मंगल", "बुध", "बिहि", "शुक्र", "शनि"]
+
+export const WEEKDAYS_LONG_NP = ["आइतबार", "सोमबार", "मंगलबार", "बुधबार", "बिहिबार", "शुक्रबार", "शनिबार"]

--- a/src/format.ts
+++ b/src/format.ts
@@ -11,11 +11,13 @@ import {
 } from "./constants"
 
 interface NepaliDate {
-    year: number;
-    month: number;
-    day: number;
-    getDay(): number;
+    year: number
+    month: number
+    day: number
+    getDay(): number
 }
+
+/* Helper functions */
 
 function pad(n: number): string {
     if (n < 10) {
@@ -32,19 +34,20 @@ function npDigit(str: string): string {
     return res
 }
 
-function yearEn(size: number): (date: NepaliDate) => string {
+/* Formatters */
+
+function yearEn(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
-        if (size <= 2) {
+        if (size === 1 || size === 4)
+            return String(date.year)
+        if (size === 2) {
             return String(date.year).substring(2)
         }
-        if (size === 3) {
-            return String(date.year).substring(1)
-        }
-        return String(date.year)
+        return format.repeat(size)
     }
 }
 
-function yearNp(size: number): (date: NepaliDate) => string {
+function yearNp(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
         if (size <= 2) {
             return npDigit(String(date.year).substring(2))
@@ -56,7 +59,7 @@ function yearNp(size: number): (date: NepaliDate) => string {
     }
 }
 
-function monthEn(size: number): (date: NepaliDate) => string {
+function monthEn(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
         if (size === 1) {
             return String(date.month + 1)
@@ -67,11 +70,14 @@ function monthEn(size: number): (date: NepaliDate) => string {
         if (size === 3) {
             return MONTHS_SHORT_EN[date.month]
         }
-        return MONTHS_EN[date.month]
+        if (size === 4) {
+            return MONTHS_EN[date.month]
+        }
+        return format.repeat(size)
     }
 }
 
-function monthNp(size: number): (date: NepaliDate) => string {
+function monthNp(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
         if (size === 1) {
             return npDigit(String(date.month + 1))
@@ -86,7 +92,7 @@ function monthNp(size: number): (date: NepaliDate) => string {
     }
 }
 
-function dateEn(size: number): (date: NepaliDate) => string {
+function dateEn(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
         if (size === 1) {
             return String(date.day)
@@ -94,10 +100,11 @@ function dateEn(size: number): (date: NepaliDate) => string {
         if (size === 2) {
             return pad(date.day)
         }
+        return format.repeat(size)
     }
 }
 
-function dateNp(size: number): (date: NepaliDate) => string {
+function dateNp(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
         if (size === 1) {
             return npDigit(String(date.day))
@@ -108,7 +115,7 @@ function dateNp(size: number): (date: NepaliDate) => string {
     }
 }
 
-function weekDayEn(size: number): (date: NepaliDate) => string {
+function weekDayEn(format: string, size: number): (date: NepaliDate) => string {
     return (date) => {
         if (size === 1) {
             return String(date.getDay())
@@ -117,7 +124,11 @@ function weekDayEn(size: number): (date: NepaliDate) => string {
             // "dd" and "ddd" => "Fri"
             return WEEKDAYS_SHORT_EN[date.getDay()]
         }
-        return WEEKDAYS_LONG_EN[date.getDay()]
+        if(size === 4){
+            return WEEKDAYS_LONG_EN[date.getDay()]
+        }
+
+        return format.repeat(size)
     }
 }
 
@@ -125,8 +136,9 @@ function pass(seq: string): () => string {
     return () => seq
 }
 
+/* formatting functions */
 
-const formatToFunctionMap: { [key: string]: (size: number) => (date: NepaliDate) => string } = {
+const formattersMap: { [key: string]: (format: string, size: number) => (date: NepaliDate) => string } = {
     Y: yearEn,
     // y: yearNp,
     M: monthEn,
@@ -136,7 +148,7 @@ const formatToFunctionMap: { [key: string]: (size: number) => (date: NepaliDate)
 }
 
 function isSpecial(ch: string) {
-    return ch in formatToFunctionMap
+    return ch in formattersMap
 }
 
 function tokenize(formatStr: string) {
@@ -156,7 +168,7 @@ function tokenize(formatStr: string) {
 
         // Time to process special
         if (special !== "") {
-            tokens.push(formatToFunctionMap[special](specialSize))
+            tokens.push(formattersMap[special](special, specialSize))
             special = ""
             specialSize = 0
         }
@@ -184,7 +196,7 @@ function tokenize(formatStr: string) {
     if (seq) {
         tokens.push(pass(seq))
     } else if (special) {
-        tokens.push(formatToFunctionMap[special](specialSize))
+        tokens.push(formattersMap[special](special, specialSize))
     }
 
     return tokens

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,40 +1,21 @@
-import NepaliDate from "./NepaliDate"
+import {
+    MONTHS_EN,
+    MONTHS_NP,
+    MONTHS_SHORT_EN,
+    MONTHS_SHORT_NP,
+    NUM_NP,
+    WEEKDAYS_LONG_EN,
+    WEEKDAYS_LONG_NP,
+    WEEKDAYS_SHORT_EN,
+    WEEKDAYS_SHORT_NP
+} from "./constants"
 
-const MONTHS_EN = [
-    "Baisakh",
-    "Jestha",
-    "Asar",
-    "Shrawan",
-    "Bhadra",
-    "Aswin",
-    "Kartik",
-    "Mangsir",
-    "Poush",
-    "Magh",
-    "Falgun",
-    "Chaitra",
-]
-const MONTHS_SHORT_EN = ["Bai", "Jes", "Asa", "Shr", "Bhd", "Asw", "Kar", "Man", "Pou", "Mag", "Fal", "Cha"]
-const MONTHS_NP = [
-    "बैशाख",
-    "जेठ",
-    "असार",
-    "श्रावण",
-    "भाद्र",
-    "आश्विन",
-    "कार्तिक",
-    "मंसिर",
-    "पौष",
-    "माघ",
-    "फाल्गुण",
-    "चैत्र",
-]
-const MONTHS_SHORT_NP = ["बै", "जे", "अ", "श्रा", "भा", "आ", "का", "मं", "पौ", "मा", "फा", "चै"]
-const NUM_NP = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"]
-const WEEKDAYS_SHORT_EN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-const WEEKDAYS_LONG_EN = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-const WEEKDAYS_SHORT_NP = ["आइत", "सोम", "मंगल", "बुध", "बिहि", "शुक्र", "शनि"]
-const WEEKDAYS_LONG_NP = ["आइतबार", "सोमबार", "मंगलबार", "बुधबार", "बिहिबार", "शुक्रबार", "शनिबार"]
+interface NepaliDate {
+    year: number;
+    month: number;
+    day: number;
+    getDay(): number;
+}
 
 function pad(n: number): string {
     if (n < 10) {
@@ -142,11 +123,11 @@ function pass(seq: any): any {
 
 const fn: { [key: string]: (size: number) => (date: NepaliDate) => string | number } = {
     Y: yearEn,
-    y: yearNp,
+    // y: yearNp,
     M: monthEn,
-    m: monthNp,
+    // m: monthNp,
     D: dateEn,
-    d: dateNp,
+    // d: dateNp,
 }
 
 function isSpecial(ch: string) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -16,7 +16,11 @@ interface NepaliDate {
     year: number
     month: number
     day: number
-    getDay(): number
+    hour: number
+    minute: number
+    weekDay: number
+    getSeconds: () => number
+    getMilliseconds: () => number
 }
 
 interface Formatter {
@@ -135,14 +139,14 @@ function dateNp(format: string, size: number): Formatter {
 function weekDayEn(format: string, size: number): Formatter {
     return (date) => {
         if (size === 1) {
-            return String(date.getDay())
+            return String(date.weekDay)
         }
         if (size > 1 && size < 4) {
             // "dd" and "ddd" => "Fri"
-            return WEEKDAYS_SHORT_EN[date.getDay()]
+            return WEEKDAYS_SHORT_EN[date.weekDay]
         }
         if (size === 4) {
-            return WEEKDAYS_LONG_EN[date.getDay()]
+            return WEEKDAYS_LONG_EN[date.weekDay]
         }
 
         return format.repeat(size)
@@ -152,16 +156,173 @@ function weekDayEn(format: string, size: number): Formatter {
 function weekDayNp(format: string, size: number): Formatter {
     return (date) => {
         if (size === 1) {
-            return npDigit(String(date.getDay()))
+            return npDigit(String(date.weekDay))
         }
         if (size > 1 && size < 4) {
-            return WEEKDAYS_SHORT_NP[date.getDay()]
+            return WEEKDAYS_SHORT_NP[date.weekDay]
         }
         if (size === 4) {
-            return WEEKDAYS_LONG_NP[date.getDay()]
+            return WEEKDAYS_LONG_NP[date.weekDay]
         }
 
         return format.repeat(size)
+    }
+}
+
+function hour24En(format: string, size: number): Formatter {
+    return (date) => {
+        if (size === 1) {
+            return String(date.hour)
+        }
+        if (size === 2) {
+            return pad(date.hour)
+        }
+        return format.repeat(size)
+    }
+}
+
+function hour24Np(format: string, size: number): Formatter {
+    return (date) => {
+        if (size === 1) {
+            return npDigit(String(date.hour))
+        }
+        if (size === 2) {
+            return npDigit(pad(date.hour))
+        }
+        return format.repeat(size)
+    }
+}
+
+function hour12En(format: string, size: number): Formatter {
+    return (date) => {
+        const hour = date.hour > 12 ? date.hour - 12 : date.hour
+
+        if (size === 1) {
+            return String(hour)
+        }
+        if (size === 2) {
+            return pad(hour)
+        }
+        return format.repeat(size)
+    }
+}
+
+function hour12Np(format: string, size: number): Formatter {
+    return (date) => {
+        const hour = date.hour > 12 ? date.hour - 12 : date.hour
+
+        if (size === 1) {
+            return npDigit(String(hour))
+        }
+        if (size === 2) {
+            return npDigit(pad(hour))
+        }
+        return format.repeat(size)
+    }
+}
+
+function minuteEn(format: string, size: number): Formatter {
+    return (date) => {
+        if (size === 1) {
+            return String(date.minute)
+        }
+        if (size === 2) {
+            return pad(date.minute)
+        }
+        return format.repeat(size)
+    }
+}
+
+function minuteNp(format: string, size: number): Formatter {
+    return (date) => {
+        if (size === 1) {
+            return npDigit(String(date.minute))
+        }
+        if (size === 2) {
+            return npDigit(pad(date.minute))
+        }
+        return format.repeat(size)
+    }
+}
+
+function secondEn(format: string, size: number): Formatter {
+    return (date) => {
+        const seconds = date.getSeconds()
+        if (size === 1) {
+            return String(seconds)
+        }
+        if (size === 2) {
+            return pad(seconds)
+        }
+        return format.repeat(size)
+    }
+}
+
+function secondNp(format: string, size: number): Formatter {
+    return (date) => {
+        const seconds = date.getSeconds()
+        if (size === 1) {
+            return npDigit(String(seconds))
+        }
+        if (size === 2) {
+            return npDigit(pad(seconds))
+        }
+        return format.repeat(size)
+    }
+}
+
+function millisecondEn(format: string, size: number): Formatter {
+    return (date) => {
+        const ms = date.getMilliseconds()
+        if (size < 4) {
+            return String(ms).substring(0, size)
+        }
+        if (size < 10) {
+            return `${ms}${'0'.repeat(size - 3)}`
+        }
+        return format.repeat(size)
+    }
+}
+
+function millisecondNp(format: string, size: number): Formatter {
+    return (date) => {
+        const ms = date.getMilliseconds()
+        if (size < 4) {
+            return npDigit(String(ms).substring(0, size))
+        }
+        if (size < 10) {
+            return npDigit(`${ms}${'0'.repeat(size - 3)}`)
+        }
+        return format.repeat(size)
+    }
+}
+
+function amPmUpperCaseEn(format: string, size: number): Formatter {
+    return (date) => {
+        return date.hour > 12 ? 'PM' : 'AM'
+    }
+}
+
+function amPmNp(format: string, size: number): Formatter {
+    return (date) => {
+        /**
+         * The output of this method is yet to be decided.
+         * Further discussion are needed for this method.
+         *
+         * The most common words used in Nepal are below:
+         * - बिहान
+         * - मध्यान्ह
+         * - दिउसो
+         * - बेलुका
+         * - रात
+         */
+        return format
+    }
+}
+
+function amPmLowerCaseEn(format: string, size: number): Formatter {
+    return (date) => {
+        return date.hour > 12 ? 'pm' : 'am'
     }
 }
 
@@ -176,11 +337,16 @@ function pass(seq: string): () => string {
  */
 const formattersFactoryMapEn: FormatterFactoryMap = {
     Y: yearEn,
-    // y: yearNp,
     M: monthEn,
-    // m: monthNp,
     D: dateEn,
     d: weekDayEn,
+    H: hour24En,
+    h: hour12En,
+    m: minuteEn,
+    s: secondEn,
+    S: millisecondEn,
+    A: amPmUpperCaseEn,
+    a: amPmLowerCaseEn,
 }
 
 /**
@@ -191,6 +357,13 @@ const formattersFactoryMapNp: FormatterFactoryMap = {
     M: monthNp,
     D: dateNp,
     d: weekDayNp,
+    H: hour24Np,
+    h: hour12Np,
+    m: minuteNp,
+    s: secondNp,
+    S: millisecondNp,
+    A: amPmNp,
+    a: amPmNp,
 }
 
 /**


### PR DESCRIPTION
- Removed formatting for nepali from `format()` method.
- Updated method for formatting. such as `Y` for a year, and `D` for a day.
- Ignored invalid format lengths, and will not be formatted. For instance, `YYYYY` and `YYY` will be returned as usual.
- Added `formatNepali` method for Nepali language representation.
- Added hour, minute, second, milliseconds formatting for both `format()` and `formatNepali`
- Minor updates on `README.md`