### PR TITLE
Added methods for Nepali year, month, date in English calendar

### DIFF
--- a/__tests__/NepaliDate.spec.ts
+++ b/__tests__/NepaliDate.spec.ts
@@ -9,8 +9,12 @@ describe("NepaliDate", () => {
         const n = new NepaliDate(new Date(373314600000))
         expect(n.toString()).toBe("2038/7/15")
         expect(n.getYear()).toBe(2038)
+        expect(n.getEnglishYear()).toBe(1981)
         expect(n.getMonth()).toBe(6)
+        expect(n.getEnglishMonth()).toBe(9)
         expect(n.getDate()).toBe(15)
+        expect(n.getEnglishDate()).toBe(31)
+        expect(n.getDateObject().getUTCDate()).toEqual(30)
         expect(n.getDay()).toBe(6)
 
         const n2 = new NepaliDate(new Date("2018-08-17"))
@@ -23,7 +27,10 @@ describe("NepaliDate", () => {
 
         const n2 = new NepaliDate("2075.03.22")
         expect(n2.toString()).toBe("2075/3/22")
-        expect(n2.getEnglishDate().toISOString()).toEqual("2018-07-05T18:15:00.000Z")
+        expect(n2.getDateObject().toISOString()).toEqual("2018-07-05T18:15:00.000Z")
+        expect(n2.getEnglishYear()).toBe(2018)
+        expect(n2.getEnglishMonth()).toBe(6)
+        expect(n2.getEnglishDate()).toBe(6)
     })
 
     it("checks parser for date and time", () => {
@@ -261,13 +268,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(678)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1944)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(4)
-        expect(d.getEnglishDate().getUTCDate()).toBe(28)
-        expect(d.getEnglishDate().getUTCHours()).toBe(12)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(26)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(45)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(678)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1944)
+        expect(d.getDateObject().getUTCMonth()).toBe(4)
+        expect(d.getDateObject().getUTCDate()).toBe(28)
+        expect(d.getDateObject().getUTCHours()).toBe(12)
+        expect(d.getDateObject().getUTCMinutes()).toBe(26)
+        expect(d.getDateObject().getUTCSeconds()).toBe(45)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(678)
     })
 
     it('should support timestamp of past year with GMT+5:30', () => {
@@ -292,13 +299,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(678)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1944)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(4)
-        expect(d.getEnglishDate().getUTCDate()).toBe(28)
-        expect(d.getEnglishDate().getUTCHours()).toBe(12)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(26)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(45)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(678)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1944)
+        expect(d.getDateObject().getUTCMonth()).toBe(4)
+        expect(d.getDateObject().getUTCDate()).toBe(28)
+        expect(d.getDateObject().getUTCHours()).toBe(12)
+        expect(d.getDateObject().getUTCMinutes()).toBe(26)
+        expect(d.getDateObject().getUTCSeconds()).toBe(45)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(678)
     })
 
     it('should support date and time of recent year with GMT+5:45', () => {
@@ -323,13 +330,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(678)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(2023)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(4)
-        expect(d.getEnglishDate().getUTCDate()).toBe(29)
-        expect(d.getEnglishDate().getUTCHours()).toBe(12)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(11)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(45)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(678)
+        expect(d.getDateObject().getUTCFullYear()).toBe(2023)
+        expect(d.getDateObject().getUTCMonth()).toBe(4)
+        expect(d.getDateObject().getUTCDate()).toBe(29)
+        expect(d.getDateObject().getUTCHours()).toBe(12)
+        expect(d.getDateObject().getUTCMinutes()).toBe(11)
+        expect(d.getDateObject().getUTCSeconds()).toBe(45)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(678)
     })
 
     it('should support timestamp of recent year with GMT+5:45', () => {
@@ -354,13 +361,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(678)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(2023)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(4)
-        expect(d.getEnglishDate().getUTCDate()).toBe(29)
-        expect(d.getEnglishDate().getUTCHours()).toBe(12)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(11)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(45)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(678)
+        expect(d.getDateObject().getUTCFullYear()).toBe(2023)
+        expect(d.getDateObject().getUTCMonth()).toBe(4)
+        expect(d.getDateObject().getUTCDate()).toBe(29)
+        expect(d.getDateObject().getUTCHours()).toBe(12)
+        expect(d.getDateObject().getUTCMinutes()).toBe(11)
+        expect(d.getDateObject().getUTCSeconds()).toBe(45)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(678)
     })
 
     it('should support date and time of edge of GMT+5:45', () => {
@@ -385,13 +392,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(0)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1985)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(11)
-        expect(d.getEnglishDate().getUTCDate()).toBe(31)
-        expect(d.getEnglishDate().getUTCHours()).toBe(18)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(30)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(0)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(0)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1985)
+        expect(d.getDateObject().getUTCMonth()).toBe(11)
+        expect(d.getDateObject().getUTCDate()).toBe(31)
+        expect(d.getDateObject().getUTCHours()).toBe(18)
+        expect(d.getDateObject().getUTCMinutes()).toBe(30)
+        expect(d.getDateObject().getUTCSeconds()).toBe(0)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(0)
     })
 
     it('should support timestamp of edge of GMT+5:45', () => {
@@ -416,13 +423,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(0)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1985)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(11)
-        expect(d.getEnglishDate().getUTCDate()).toBe(31)
-        expect(d.getEnglishDate().getUTCHours()).toBe(18)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(30)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(0)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(0)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1985)
+        expect(d.getDateObject().getUTCMonth()).toBe(11)
+        expect(d.getDateObject().getUTCDate()).toBe(31)
+        expect(d.getDateObject().getUTCHours()).toBe(18)
+        expect(d.getDateObject().getUTCMinutes()).toBe(30)
+        expect(d.getDateObject().getUTCSeconds()).toBe(0)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(0)
     })
 
     it('should support date and time of edge of GMT+5:30', () => {
@@ -447,13 +454,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(999)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1985)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(11)
-        expect(d.getEnglishDate().getUTCDate()).toBe(31)
-        expect(d.getEnglishDate().getUTCHours()).toBe(18)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(29)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(59)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(999)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1985)
+        expect(d.getDateObject().getUTCMonth()).toBe(11)
+        expect(d.getDateObject().getUTCDate()).toBe(31)
+        expect(d.getDateObject().getUTCHours()).toBe(18)
+        expect(d.getDateObject().getUTCMinutes()).toBe(29)
+        expect(d.getDateObject().getUTCSeconds()).toBe(59)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(999)
     })
 
     it('should support timestamp of edge of GMT+5:30', () => {
@@ -478,13 +485,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(999)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1985)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(11)
-        expect(d.getEnglishDate().getUTCDate()).toBe(31)
-        expect(d.getEnglishDate().getUTCHours()).toBe(18)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(29)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(59)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(999)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1985)
+        expect(d.getDateObject().getUTCMonth()).toBe(11)
+        expect(d.getDateObject().getUTCDate()).toBe(31)
+        expect(d.getDateObject().getUTCHours()).toBe(18)
+        expect(d.getDateObject().getUTCMinutes()).toBe(29)
+        expect(d.getDateObject().getUTCSeconds()).toBe(59)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(999)
     })
 
     it('should support date and time of edge of GMT+5:45 after 15 minutes', () => {
@@ -509,13 +516,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(0)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1985)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(11)
-        expect(d.getEnglishDate().getUTCDate()).toBe(31)
-        expect(d.getEnglishDate().getUTCHours()).toBe(18)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(31)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(0)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(0)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1985)
+        expect(d.getDateObject().getUTCMonth()).toBe(11)
+        expect(d.getDateObject().getUTCDate()).toBe(31)
+        expect(d.getDateObject().getUTCHours()).toBe(18)
+        expect(d.getDateObject().getUTCMinutes()).toBe(31)
+        expect(d.getDateObject().getUTCSeconds()).toBe(0)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(0)
     })
 
     it('should support timestamp of edge of GMT+5:45 after 15 minutes', () => {
@@ -540,13 +547,13 @@ describe("NepaliDate with Time feature initialization", () => {
         expect(d.getMilliseconds()).toBe(0)
 
         // english dates and times
-        expect(d.getEnglishDate().getUTCFullYear()).toBe(1985)
-        expect(d.getEnglishDate().getUTCMonth()).toBe(11)
-        expect(d.getEnglishDate().getUTCDate()).toBe(31)
-        expect(d.getEnglishDate().getUTCHours()).toBe(18)
-        expect(d.getEnglishDate().getUTCMinutes()).toBe(31)
-        expect(d.getEnglishDate().getUTCSeconds()).toBe(0)
-        expect(d.getEnglishDate().getUTCMilliseconds()).toBe(0)
+        expect(d.getDateObject().getUTCFullYear()).toBe(1985)
+        expect(d.getDateObject().getUTCMonth()).toBe(11)
+        expect(d.getDateObject().getUTCDate()).toBe(31)
+        expect(d.getDateObject().getUTCHours()).toBe(18)
+        expect(d.getDateObject().getUTCMinutes()).toBe(31)
+        expect(d.getDateObject().getUTCSeconds()).toBe(0)
+        expect(d.getDateObject().getUTCMilliseconds()).toBe(0)
     })
 })
 

--- a/src/NepaliDate.ts
+++ b/src/NepaliDate.ts
@@ -8,8 +8,11 @@ import { validateTime } from "./validators"
 class NepaliDate {
     timestamp: Date
     year: number
+    yearEn: number
     month: number
+    monthEn: number
     day: number
+    dayEn: number
     hour: number
     minute: number
     weekDay: number
@@ -18,12 +21,12 @@ class NepaliDate {
 
     constructor(...args: any[]) {
         if (args.length === 0) {
-            this.setEnglishDate(new Date())
+            this._setDateObject(new Date())
         } else if (args.length === 1) {
             const e = args[0]
             if (typeof e === "object") {
                 if (e instanceof Date) {
-                    this.setEnglishDate(e)
+                    this._setDateObject(e)
                 } else if (e instanceof NepaliDate) {
                     this.timestamp = e.timestamp
                     this.year = e.year
@@ -36,7 +39,7 @@ class NepaliDate {
                     throw new Error("Invalid date argument")
                 }
             } else if (typeof e === "number") {
-                this.setEnglishDate(new Date(e))
+                this._setDateObject(new Date(e))
             }
             else if (typeof e === "string") {
                 // Try to parse the date
@@ -65,11 +68,14 @@ class NepaliDate {
      * @param computeNepaliDate Flag indicating whether to compute the Nepali date. Default is `false`.
      * @returns void
      */
-    private _setEnglishDate(date: Date, computeNepaliDate: boolean = false) {
+    private _setDateObject(date: Date, computeNepaliDate: boolean = true) {
         this.timestamp = date
 
         // getting Nepal's hour, minute, and weekDay
         const { year, month0, day, hour, minute, weekDay } = getNepalDateAndTime(date)
+        this.yearEn = year
+        this.monthEn = month0
+        this.dayEn = day
         this.hour = hour
         this.minute = minute
         this.weekDay = weekDay
@@ -82,11 +88,7 @@ class NepaliDate {
         }
     }
 
-    setEnglishDate(date: Date) {
-        this._setEnglishDate(date, true)
-    }
-
-    getEnglishDate() {
+    getDateObject() {
         return this.timestamp
     }
 
@@ -94,21 +96,58 @@ class NepaliDate {
         this.set.apply(this, parse(dateString))
     }
 
+    /**
+     * Retrieves the year of the Nepali date in the Nepali calendar.
+     *
+     * @returns {number} The full numeric value representing the year. Eg. 2080
+     */
     getYear(): number {
         return this.year
     }
 
+    /**
+     * Retrieves the year of the Nepali date in the English calendar.
+     *
+     * @returns {number} The full numeric value representing the year. Eg. 2009
+     */
+    getEnglishYear(): number {
+        return this.yearEn
+    }
+
+    /**
+     * Retrieves the month of the Nepali date in the Nepali calendar.
+     *
+     * @returns {number} The numeric value representing the month. 0 for Baishakh and 11 for Chaitra.
+     */
     getMonth(): number {
         return this.month
     }
 
     /**
-     * Get the day of the month represented by a numeric value.
+     * Retrieves the month of the Nepali date in the English calendar.
      *
-     * @returns The numeric value representing the day of the month.
+     * @returns {number} The numeric value representing the month. 0 for January and 11 for December.
+     */
+    getEnglishMonth(): number {
+        return this.monthEn
+    }
+
+    /**
+     * Retrieves the day of the month represented of Nepali date in Nepali calendar.
+     *
+     * @returns {number} The numeric value representing the day of the month.
      */
     getDate(): number {
         return this.day
+    }
+
+    /**
+     * Retrieves the day of the month represented of Nepali date in English calendar.
+     *
+     * @returns {number} The numeric value representing the day of the month.
+     */
+    getEnglishDate(): number {
+        return this.dayEn
     }
 
     /**
@@ -266,7 +305,7 @@ class NepaliDate {
      * @returns void
      */
     setTime(time: number) {
-        this.setEnglishDate(new Date(time))
+        this._setDateObject(new Date(time))
     }
 
     set(year: number, month: number, date: number,
@@ -276,7 +315,7 @@ class NepaliDate {
         this.year = year
         this.month = month
         this.day = date
-        this._setEnglishDate(getDate(yearEn, month0EN, dayEn, hour, minute, second, ms))
+        this._setDateObject(getDate(yearEn, month0EN, dayEn, hour, minute, second, ms), false)
     }
 
     format(formatStr: string) {


### PR DESCRIPTION
- Renamed method getEnglishDate to getDateObject
- Removed public method setEnglishDate
- Added method for year, month, and date in the English calendar
- Fixes #26 