### PR TITLE
refactor: rename `month0` to `month` for consistent 0-indexed convention

### DIFF
--- a/src/NepalTimezoneDate.ts
+++ b/src/NepalTimezoneDate.ts
@@ -26,7 +26,7 @@ class NepalTimezoneDate {
     private _date: Date
     private _nepalTimezoneSafeDate: {
         year: number
-        month0: number
+        month: number
         day: number
         hour: number
         minute: number
@@ -58,7 +58,7 @@ class NepalTimezoneDate {
 
         // Extract the Nepali date and time components
         const npYear = nepaliRefDate.getUTCFullYear()
-        const npMonth0 = nepaliRefDate.getUTCMonth()
+        const npMonth = nepaliRefDate.getUTCMonth()
         const npDay = nepaliRefDate.getUTCDate()
         const npHour = nepaliRefDate.getUTCHours()
         const npMinutes = nepaliRefDate.getUTCMinutes()
@@ -69,7 +69,7 @@ class NepalTimezoneDate {
         // Return the Nepali date and time components as an object
         return {
             year: npYear,
-            month0: npMonth0,
+            month: npMonth,
             day: npDay,
             hour: npHour,
             minute: npMinutes,
@@ -83,7 +83,7 @@ class NepalTimezoneDate {
      * Get the Date object from the given Nepali date and time components.
      *
      * @param year - The year component of the Nepali date.
-     * @param month0 - The month component of the Nepali date (1-12).
+     * @param month - The month component of the Nepali date (0-11).
      * @param date - The day component of the Nepali date.
      * @param hour - The hour component of the Nepali time.
      * @param minute - The minute component of the Nepali time.
@@ -173,7 +173,7 @@ class NepalTimezoneDate {
      * @returns {number} The numeric value representing the month
      */
     getMonth(): number {
-        return this._nepalTimezoneSafeDate.month0
+        return this._nepalTimezoneSafeDate.month
     }
 
     /**
@@ -239,7 +239,7 @@ class NepalTimezoneDate {
     toString(): string {
         const np = this._nepalTimezoneSafeDate
         return (
-            `${np.year}-${String(np.month0 + 1).padStart(2, '0')}-${String(np.day).padStart(2, '0')} ` +
+            `${np.year}-${String(np.month + 1).padStart(2, '0')}-${String(np.day).padStart(2, '0')} ` +
             `${String(np.hour).padStart(2, '0')}:${String(np.minute).padStart(2, '0')}:${String(np.second).padStart(2, '0')} GMT+0545`
         )
     }

--- a/src/NepaliDate.ts
+++ b/src/NepaliDate.ts
@@ -252,13 +252,13 @@ class NepaliDate {
         this.weekDay = npTzDate.getDay()
 
         if (computeNepaliDate) {
-            const [yearNp, month0Np, dayNp] = dateConverter.englishToNepali(
+            const [yearNp, monthNp, dayNp] = dateConverter.englishToNepali(
                 this.yearEn,
                 this.monthEn,
                 this.dayEn
             )
             this.year = yearNp
-            this.month = month0Np
+            this.month = monthNp
             this.day = dayNp
         }
     }
@@ -543,7 +543,7 @@ class NepaliDate {
         ms: number
     ) {
         validateTime(hour, minute, second, ms)
-        const [yearEn, month0EN, dayEn] = dateConverter.nepaliToEnglish(
+        const [yearEn, monthEn, dayEn] = dateConverter.nepaliToEnglish(
             year,
             month,
             date
@@ -554,7 +554,7 @@ class NepaliDate {
         this._setDateObject(
             NepalTimezoneDate['getDate'](
                 yearEn,
-                month0EN,
+                monthEn,
                 dayEn,
                 hour,
                 minute,
@@ -628,7 +628,7 @@ class NepaliDate {
      * Creates a new instance of NepaliDate from an English calendar parameters.
      *
      * @param year - The year in English calendar format.
-     * @param month0 - The month (0-11) in English calendar format.
+     * @param month - The month (0-11) in English calendar format.
      * @param date - The day of the month in English calendar format.
      * @param hour - The hour (0-23) in English calendar format. Default is 0.
      * @param minute - The minute (0-59) in English calendar format. Default is 0.
@@ -638,7 +638,7 @@ class NepaliDate {
      */
     static fromEnglishDate(
         year: number,
-        month0: number,
+        month: number,
         date: number,
         hour: number = 0,
         minute: number = 0,
@@ -647,7 +647,7 @@ class NepaliDate {
     ): NepaliDate {
         const englishDate = NepalTimezoneDate['getDate'](
             year,
-            month0,
+            month,
             date,
             hour,
             minute,
@@ -669,11 +669,11 @@ class NepaliDate {
      * const nepaliDate = NepaliDate.parseNepaliFormat(dateStringNe, format)
      */
     static parseNepaliFormat(dateStringNe: string, format: string): NepaliDate {
-        const [year, month0, day, hour, minute, second, ms] = parseNepaliFormat(
+        const [year, month, day, hour, minute, second, ms] = parseNepaliFormat(
             dateStringNe,
             format
         )
-        return new NepaliDate(year, month0, day, hour, minute, second, ms)
+        return new NepaliDate(year, month, day, hour, minute, second, ms)
     }
 
     /**
@@ -688,11 +688,11 @@ class NepaliDate {
      * const nepaliDate = NepaliDate.parseEnglishDate(dateTimeString, format)
      */
     static parseEnglishDate(dateString: string, format: string): NepaliDate {
-        const [year, month0, day, hour, minute, second, ms] = parseEnglishDateFormat(
+        const [year, month, day, hour, minute, second, ms] = parseEnglishDateFormat(
             dateString,
             format
         )
-        return NepaliDate.fromEnglishDate(year, month0, day, hour, minute, second, ms)
+        return NepaliDate.fromEnglishDate(year, month, day, hour, minute, second, ms)
     }
 
     /**

--- a/src/dateConverter/dateConverter.ts
+++ b/src/dateConverter/dateConverter.ts
@@ -7,10 +7,10 @@
  *
  * Functions:
  *
- * - `englishToNepali(year: number, month0: number, day: number): [number, number, number]`
+ * - `englishToNepali(year: number, month: number, day: number): [number, number, number]`
  *   Converts a given English (Gregorian) date to Nepali date.
  *
- * - `nepaliToEnglish(year: number, month0: number, day: number): [number, number, number]`
+ * - `nepaliToEnglish(year: number, month: number, day: number): [number, number, number]`
  *   Converts a given Nepali date to English (Gregorian) date.
  *
  * - `DateOutOfRangeError`
@@ -30,10 +30,8 @@
  * console.log(`English Date: ${enYear}-${enMonth}-${enDay}`);
  * ```
  *
- * Note: There are two types of month variables used in this file.
- * The first is `month0`, which represents month values starting from 0,
- * for example, 0 for January and 0 for Baishakh.
- * The second is `month`, which represents month values starting from 1.
+ * Note: The `month` parameter in the public API is 0-indexed (0-11),
+ * matching JavaScript's Date.getMonth() convention.
  */
 import {
     NP_INITIAL_YEAR,
@@ -155,21 +153,21 @@ const _getTotalDaysFromEnglishDate = (
 /**
  * Converts an English date to Nepali date.
  * @param year - The year in English calendar.
- * @param month0 - The month in English calendar. Starting from 0, 0 for January.
+ * @param month - The month in English calendar. Starting from 0, 0 for January.
  * @param day - The day in English calendar.
  * @returns The corresponding Nepali date as an array of [year, month, day].
  * @throws {DateOutOfRangeError} If the provided date is out of range.
  */
 function englishToNepali(
     year: number,
-    month0: number,
+    month: number,
     day: number
 ): [number, number, number] {
-    const month = month0 + 1
+    const month1Indexed = month + 1
 
     // VALIDATION
     // checking if date is in range
-    if (!_checkEnglishDate(year, month, day)) {
+    if (!_checkEnglishDate(year, month1Indexed, day)) {
         throw new DateOutOfRangeError('Date out of range')
     }
 
@@ -181,7 +179,7 @@ function englishToNepali(
     // DIFFERENCE
     // calculating days count from the reference date
     let difference: number = Math.abs(
-        _getTotalDaysFromEnglishDate(year, month, day) -
+        _getTotalDaysFromEnglishDate(year, month1Indexed, day) -
             _getTotalDaysFromEnglishDate(...REFERENCE_EN_DATE)
     )
 
@@ -260,20 +258,20 @@ const _getTotalDaysFromNepaliDate = (
 /**
  * Converts a Nepali date to the corresponding English date.
  * @param year - The year in Nepali calendar.
- * @param month - The month in Nepali calendar.
- * @param day - The day in Nepali calendar. Starting from 0, 0 for Baishakh.
+ * @param month - The month in Nepali calendar. Starting from 0, 0 for Baishakh.
+ * @param day - The day in Nepali calendar.
  * @returns An array containing the corresponding English year, month, and day.
  * @throws {DateOutOfRangeError} If the provided Nepali date is out of range.
  */
 const nepaliToEnglish = (
     year: number,
-    month0: number,
+    month: number,
     day: number
 ): [number, number, number] => {
-    const month = month0 + 1
+    const month1Indexed = month + 1
 
     // VALIDATION
-    if (!_checkNepaliDate(year, month, day)) {
+    if (!_checkNepaliDate(year, month1Indexed, day)) {
         throw new DateOutOfRangeError('Date out of range')
     }
 
@@ -293,7 +291,7 @@ const nepaliToEnglish = (
     // DIFFERENCE
     // calculating days count from the reference date
     let difference: number = Math.abs(
-        _getTotalDaysFromNepaliDate(year, month, day) + reference_diff
+        _getTotalDaysFromNepaliDate(year, month1Indexed, day) + reference_diff
     )
 
     // YEAR

--- a/src/parse/parse.ts
+++ b/src/parse/parse.ts
@@ -20,7 +20,7 @@ import { parseFormatTokens, seqToRE } from '../utils'
  *
  * @param dateString date string to be parsed.
  * @throws {Error} if date string is invalid
- * @returns return array of date information [year, month0, day].
+ * @returns return array of date information [year, month, day].
  */
 function parseDateString(dateString: string): number[] {
     // Expected date formats are yyyy-mm-dd, yyyy.mm.dd yyyy/mm/dd
@@ -84,9 +84,9 @@ function parseTimeString(timeString: string): number[] {
  */
 export function simpleParse(dateTimeString: string): number[] {
     const [dateString, timeString] = dateTimeString.split(' ', 2)
-    const [year, month0, day] = parseDateString(dateString)
+    const [year, month, day] = parseDateString(dateString)
     const [hour, minute, second, ms] = parseTimeString(timeString)
-    return [year, month0, day, hour, minute, second, ms]
+    return [year, month, day, hour, minute, second, ms]
 }
 
 /* parse v2 */
@@ -200,7 +200,7 @@ function getDateParams(
 
     return {
         year,
-        month0: month - 1,
+        month: month - 1,
         day,
         hour,
         minute,
@@ -217,9 +217,9 @@ export function parseFormat(dateString: string, format: string): number[] {
         throw new Error('Invalid date format')
     }
 
-    const { year, month0, day, hour, minute, second, ms } = getDateParams(
+    const { year, month, day, hour, minute, second, ms } = getDateParams(
         dateTokens,
         match
     )
-    return [year, month0, day, hour, minute, second, ms]
+    return [year, month, day, hour, minute, second, ms]
 }

--- a/src/parse/parseEnglishDate.ts
+++ b/src/parse/parseEnglishDate.ts
@@ -59,7 +59,9 @@ function getDateParams(
     match: RegExpMatchArray
 ): { [key: string]: number } {
     // month and day are set to 1 in default
-    let [year, month, day, hour, hour12, minute, second, ms] = [0, 1, 1, 0, 0, 0, 0, 0]
+    let [year, month1Indexed, day, hour, hour12, minute, second, ms] = [
+        0, 1, 1, 0, 0, 0, 0, 0,
+    ]
     let isPM = false
     let is12hourFormat = false
 
@@ -75,13 +77,13 @@ function getDateParams(
                 break
             case 'MM':
             case 'M':
-                month = matchData
+                month1Indexed = matchData
                 break
             case 'MMMM':
-                month = ENGLISH_MONTHS_EN.indexOf(match[i + 1]) + 1
+                month1Indexed = ENGLISH_MONTHS_EN.indexOf(match[i + 1]) + 1
                 break
             case 'MMM':
-                month = ENGLISH_MONTHS_SHORT_EN.indexOf(match[i + 1]) + 1
+                month1Indexed = ENGLISH_MONTHS_SHORT_EN.indexOf(match[i + 1]) + 1
                 break
             case 'DD':
             case 'D':
@@ -119,7 +121,7 @@ function getDateParams(
 
     return {
         year,
-        month0: month - 1,
+        month: month1Indexed - 1,
         day,
         hour,
         minute,
@@ -136,9 +138,9 @@ export function parseEnglishDateFormat(dateString: string, format: string): numb
         throw new Error('Invalid date format')
     }
 
-    const { year, month0, day, hour, minute, second, ms } = getDateParams(
+    const { year, month, day, hour, minute, second, ms } = getDateParams(
         dateTokens,
         match
     )
-    return [year, month0, day, hour, minute, second, ms]
+    return [year, month, day, hour, minute, second, ms]
 }


### PR DESCRIPTION
## Summary
- Standardize month variable naming so `month` always means 0-indexed (0-11), matching JavaScript's `Date.getMonth()` convention
- Rename internal 1-indexed `month` variables to `month1Indexed` in `dateConverter.ts`
- Update interface properties, local variables, return objects, destructuring, and JSDoc across 5 files

Closes #97

## Changes
- **`src/dateConverter/dateConverter.ts`**: Rename parameter `month0` → `month` in `englishToNepali()` and `nepaliToEnglish()`, rename internal `const month` → `const month1Indexed`
- **`src/NepalTimezoneDate.ts`**: Rename interface property `month0` → `month`, local variable `npMonth0` → `npMonth`, fix JSDoc on `getDate()`
- **`src/parse/parse.ts`**: Rename local variable and return property `month0` → `month`
- **`src/parse/parseEnglishDate.ts`**: Rename return property `month0` → `month`
- **`src/NepaliDate.ts`**: Rename `month0Np` → `monthNp`, `month0EN` → `monthEn`, `month0` → `month` in `fromEnglishDate()` and static parse methods

## Test plan
- [x] All 339 existing tests pass without modification
- [x] No remaining `month0` references in `src/`
- [x] Pre-commit hooks (prettier, lint-staged, jest) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)